### PR TITLE
Feature/remove address lookup

### DIFF
--- a/app/views/versions/v11/bereavement-support-payments/questions.html
+++ b/app/views/versions/v11/bereavement-support-payments/questions.html
@@ -112,7 +112,7 @@
         {% set bspAddressQuestionHtml %}
           <div id="bsp-address-group">
             {% set prefix = "bsp" %}
-            {% include "includes/address-lookup.html" %}
+            {% include "versions/v11/includes/manual-address.html" %}
           </div>
         {% endset %}
 

--- a/app/views/versions/v11/death-arrears-payee/administrator-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/administrator-payee.html
@@ -4,7 +4,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   {% set administratorHeading = "Administrator's details" %}
@@ -93,7 +93,7 @@
     {% else %}
       <div class="govuk-form-group dap-address">
         {% set prefix = "dap" %}
-        {% include "includes/address-lookup.html" %}
+        {% include "versions/v11/includes/manual-address.html" %}
       </div>
     {% endif %}
 

--- a/app/views/versions/v11/death-arrears-payee/beneficiary-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/beneficiary-payee.html
@@ -35,7 +35,7 @@
 
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
 
     {{ govukButton({

--- a/app/views/versions/v11/death-arrears-payee/executor-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/executor-payee.html
@@ -4,7 +4,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   {% set executorHeading = "death_arrears_who_we_will_pay" | translate %}
@@ -93,7 +93,7 @@
     {% else %}
       <div class="govuk-form-group dap-address">
         {% set prefix = "dap" %}
-        {% include "includes/address-lookup.html" %}
+        {% include "versions/v11/includes/manual-address.html" %}
       </div>
     {% endif %}
 

--- a/app/views/versions/v11/death-arrears-payee/funeral-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/funeral-payee.html
@@ -35,7 +35,7 @@
 
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
 
     {{ govukButton({

--- a/app/views/versions/v11/death-arrears-payee/maintainer-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/maintainer-payee.html
@@ -35,7 +35,7 @@
 
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
 
     {{ govukButton({

--- a/app/views/versions/v11/death-arrears-payee/next-of-kin-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/next-of-kin-payee.html
@@ -4,7 +4,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   {% set nokHeading = "Next of kin's details" %}
@@ -79,7 +79,7 @@
     {% else %}
       <div class="govuk-form-group dap-address">
         {% set prefix = "dap" %}
-        {% include "includes/address-lookup.html" %}
+        {% include "versions/v11/includes/manual-address.html" %}
       </div>
     {% endif %}
 

--- a/app/views/versions/v11/death-arrears-payee/next-of-kin-responsible.html
+++ b/app/views/versions/v11/death-arrears-payee/next-of-kin-responsible.html
@@ -4,7 +4,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   {% set question = "Are they dealing with the financial affairs of the person who's died?" %}

--- a/app/views/versions/v11/death-arrears-payee/not-found-payee.html
+++ b/app/views/versions/v11/death-arrears-payee/not-found-payee.html
@@ -5,7 +5,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   {% set notFoundHeading = "Payee's details" %}
@@ -94,7 +94,7 @@
     {% else %}
       <div class="govuk-form-group dap-address">
         {% set prefix = "dap" %}
-        {% include "includes/address-lookup.html" %}
+        {% include "versions/v11/includes/manual-address.html" %}
       </div>
     {% endif %}
 

--- a/app/views/versions/v11/death-arrears-payee/personal-details.html
+++ b/app/views/versions/v11/death-arrears-payee/personal-details.html
@@ -1,0 +1,106 @@
+{{ govukInput({
+  label: {
+    text: "full_name" | translate,
+    classes: "govuk-!-font-weight-bold",
+    attributes: {
+      id: "dap-full-name-group"
+    }
+  },
+  id: "dap-full-name",
+  name: "dap-full-name",
+  classes: "govuk-!-width-two-thirds",
+  value: data["executor-full-name"]
+}) }}
+
+{{ govukInput({
+  label: {
+    text: "company_name" | translate,
+    classes: "govuk-!-font-weight-bold",
+    attributes: {
+      id: "dap-company-name-group"
+    }
+  },
+  id: "dap-company-name",
+  name: "dap-company-name",
+  classes: "govuk-!-width-two-thirds",
+  value: data["executor-company-name"]
+}) }}
+
+{% if not data["executor-company-name"] %}
+  {{ govukInput({
+    label: {
+      text: "national_insurance" | translate,
+      classes: "govuk-!-font-weight-bold",
+      attributes: {
+        id: "dap-national-insurance-group"
+      }
+    },
+    id: "dap-national-insurance",
+    name: "dap-national-insurance",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-national-insurance"]
+  }) }}
+{% endif %}
+
+{% if data['executor-line-1'] %}
+  {{ govukInput({
+    label: {
+      text: "building_line_1" | translate | safe,
+      classes: "govuk-!-font-weight-bold"
+    },
+    id:  "executor-line-1",
+    name:  "executor-line-1",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-line-1"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "building_line_2" | translate,
+      classes: "govuk-visually-hidden govuk-!-font-weight-bold"
+    },
+    id:  "executor-line-2",
+    name:  "executor-line-2",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-line-2"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "town_city" | translate,
+      classes: "govuk-!-font-weight-bold"
+    },
+    id:  "executor-town-city",
+    name:  "executor-town-city",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-town-city"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "county" | translate,
+      classes: "govuk-!-font-weight-bold"
+    },
+    id:  "executor-county",
+    name:  "executor-county",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-county"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "postcode" | translate,
+      classes: "govuk-!-font-weight-bold"
+    },
+    id:  "executor-postcode",
+    name:  "executor-postcode",
+    classes: "govuk-!-width-two-thirds",
+    value: data["executor-postcode"]
+  }) }}
+{% else %}
+  <div class="govuk-form-group hide-address-fix">
+    {% set prefix = "dap" %}
+    {% set address_label = "death_arrears_address" | translate %}
+    {% include "versions/v11/includes/manual-address.html" %}
+  </div>
+{% endif %}

--- a/app/views/versions/v11/death-arrears-payee/who-letter.html
+++ b/app/views/versions/v11/death-arrears-payee/who-letter.html
@@ -4,7 +4,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   <h1 class="govuk-heading-l">Your contact details</h1>
@@ -75,7 +75,7 @@
     {% else %}
       <div class="govuk-form-group dap-address">
         {% set prefix = "dap" %}
-        {% include "includes/address-lookup.html" %}
+        {% include "versions/v11/includes/manual-address.html" %}
       </div>
     {% endif %}
 

--- a/app/views/versions/v11/death-arrears-payee/who-should-we-pay.html
+++ b/app/views/versions/v11/death-arrears-payee/who-should-we-pay.html
@@ -5,7 +5,7 @@
   {% set dapHtml %}
     <div class="govuk-form-group dap-address">
       {% set prefix = "dap" %}
-      {% include "includes/address-lookup.html" %}
+      {% include "versions/v11/includes/manual-address.html" %}
     </div>
   {% endset %}
   <form method="post" action="other-payee">

--- a/app/views/versions/v11/includes/deceased-benefits-list.html
+++ b/app/views/versions/v11/includes/deceased-benefits-list.html
@@ -1,0 +1,27 @@
+{% from "checkboxes/macro.njk"    import govukCheckboxes %}
+
+<div>
+  {# {{ govukTag({
+    attributes: { id: "eligibility-completed" },
+    classes: "app-task-list__task-completed tag-red",
+    text: "Do not read out to the caller"
+  }) }} #}
+</div>
+
+<div id="deceased-benefits-group">
+  {{ govukCheckboxes({
+    idPrefix: "qualifying-benefits",
+    name: "deceased-qualifying-benefits",
+    fieldset: {
+      legend: {
+        text: "deceased_qualifying_benefits" | translate,
+        isPageHeading: false,
+        classes: "govuk-fieldset__legend--s"
+      }
+    },
+    hint: {
+      text: "deceased_qualifying_benefits_hint" | translate
+    },
+    items: qualifyingBenefits
+  }) }}
+</div>

--- a/app/views/versions/v11/includes/deceased.html
+++ b/app/views/versions/v11/includes/deceased.html
@@ -54,7 +54,7 @@
 
 <div class="govuk-form-group deceased-address" id="deceased-address-group">
   {% set prefix = "deceased" %}
-  {% include "includes/address-lookup.html" %}
+  {% include "versions/v11/includes/manual-address.html" %}
 </div>
 
 <div id="deceased-dod-group">

--- a/app/views/versions/v11/includes/manual-address.html
+++ b/app/views/versions/v11/includes/manual-address.html
@@ -1,7 +1,7 @@
 {% call govukFieldset({
   classes: 'address-group',
   legend: {
-    html: "address" | translate + "<span class='govuk-hint'>" + "address_hint" | translate + "</span>",
+    html: "address" | translate,
     classes: "govuk-fieldset__legend--s",
     isPageHeading: false
   }

--- a/app/views/versions/v11/includes/manual-address.html
+++ b/app/views/versions/v11/includes/manual-address.html
@@ -1,7 +1,7 @@
 {% call govukFieldset({
   classes: 'address-group',
   legend: {
-    html: "address" | translate,
+    html: address_label or "address" | translate,
     classes: "govuk-fieldset__legend--s",
     isPageHeading: false
   }

--- a/app/views/versions/v11/includes/manual-address.html
+++ b/app/views/versions/v11/includes/manual-address.html
@@ -1,0 +1,59 @@
+{% call govukFieldset({
+  classes: 'address-group',
+  legend: {
+    html: "address" | translate + "<span class='govuk-hint'>" + "address_hint" | translate + "</span>",
+    classes: "govuk-fieldset__legend--s",
+    isPageHeading: false
+  }
+}) %}
+  {{ govukInput({
+    label: {
+      text: "building_line_1" | translate | safe
+    },
+    id:  prefix + "-line-1",
+    name:  prefix + "-line-1",
+    classes: "govuk-!-width-two-thirds",
+    value: data[prefix + "-line-1"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "building_line_2" | translate,
+      classes: "govuk-visually-hidden"
+    },
+    id:  prefix + "-line-2",
+    name:  prefix + "-line-2",
+    classes: "govuk-!-width-two-thirds",
+    value: data[prefix + "-line-2"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "town_city" | translate
+    },
+    id:  prefix + "-town-city",
+    name:  prefix + "-town-city",
+    classes: "govuk-!-width-two-thirds",
+    value: data[prefix + "-town-city"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "county" | translate
+    },
+    id:  prefix + "-county",
+    name:  prefix + "-county",
+    classes: "govuk-!-width-two-thirds",
+    value: data[prefix + "-county"]
+  }) }}
+
+  {{ govukInput({
+    label: {
+      text: "postcode" | translate
+    },
+    id:  prefix + "-postcode",
+    name:  prefix + "-postcode",
+    classes: "govuk-!-width-two-thirds",
+    value: data[prefix + "-postcode"]
+  }) }}
+{% endcall %}

--- a/app/views/versions/v11/payee-details.html
+++ b/app/views/versions/v11/payee-details.html
@@ -11,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">{{title}}</h1>
       <form method="post" action="payee-bank">
-        {% include "versions/v6/includes/dap/personal-details.html" %}
+        {% include "versions/v11/death-arrears-payee/personal-details.html" %}
         {{ govukButton({
           text: "continue" | translate,
           id: "continue-to-payee"


### PR DESCRIPTION
Removes the address lookup functionality from version 11, and replaces it with the full set of address fields.

For the moment, I've removed the hint as it was always the same and didn't make sense in the different contexts. If needed, we could set the hint before the include to make it dynamic.